### PR TITLE
Modify /job API to allow query parameters

### DIFF
--- a/backend/controllers/jobController.go
+++ b/backend/controllers/jobController.go
@@ -88,35 +88,58 @@ func (jc *JobController) CreateJob(c *gin.Context) {
 }
 
 func (jc *JobController) GetJobs(c *gin.Context) {
-	jobIDStr := c.Param("id")
+	var jobs []models.Job
+	query := jc.DB.Preload("Company")
 
-	if jobIDStr != "" {
-		u, err := strconv.ParseUint(jobIDStr, 10, strconv.IntSize)
-
-		if err != nil {
+	if idStr := c.Query("id"); idStr != "" {
+		if id, err := strconv.Atoi(idStr); err == nil {
+			query = query.Where("id = ?", id)
+		} else {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
 			return
 		}
+	}
 
-		jobID := uint(u)
-
-		job := models.Job{
-			ID: jobID,
+	if location := c.Query("location"); location != "" {
+		query = query.Where("location = ?", location)
+	}
+	if jobType := c.Query("job_type"); jobType != "" {
+		query = query.Where("job_type = ?", jobType)
+	}
+	if employmentStatus := c.Query("employment_status"); employmentStatus != "" {
+		query = query.Where("employment_status = ?", employmentStatus)
+	}
+	if minSalary := c.Query("min_salary"); minSalary != "" {
+		if minSal, err := strconv.Atoi(minSalary); err == nil {
+			query = query.Where("min_salary >= ?", minSal)
 		}
-
-		if err := jc.DB.Preload("Company.User").First(&job).Error; err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
+	}
+	if maxSalary := c.Query("max_salary"); maxSalary != "" {
+		if maxSal, err := strconv.Atoi(maxSalary); err == nil {
+			query = query.Where("max_salary <= ?", maxSal)
 		}
+	}
+	if minExperience := c.Query("min_experience"); minExperience != "" {
+		if minExp, err := strconv.Atoi(minExperience); err == nil {
+			query = query.Where("min_experience >= ?", minExp)
+		}
+	}
+	if maxExperience := c.Query("max_experience"); maxExperience != "" {
+		if maxExp, err := strconv.Atoi(maxExperience); err == nil {
+			query = query.Where("max_experience <= ?", maxExp)
+		}
+	}
+	if visibility := c.Query("visibility"); visibility != "" {
+		query = query.Where("visibility = ?", visibility)
+	}
 
-		c.JSON(http.StatusOK, gin.H{"job": job})
+	if err := query.Find(&jobs).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	var jobs []models.Job
-
-	if err := jc.DB.Preload("Company.User").Find(&jobs).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if len(jobs) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"message": "no jobs found"})
 		return
 	}
 

--- a/backend/controllers/jobController.go
+++ b/backend/controllers/jobController.go
@@ -133,6 +133,18 @@ func (jc *JobController) GetJobs(c *gin.Context) {
 		query = query.Where("visibility = ?", visibility)
 	}
 
+	limit, err := strconv.Atoi(c.DefaultQuery("limit", "30"))
+	if err != nil || limit <= 0 {
+		limit = 30
+	}
+
+	offset, err := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
+	query = query.Limit(limit).Offset(offset)
+
 	if err := query.Find(&jobs).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/controllers/jobController.go
+++ b/backend/controllers/jobController.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"com-seek/backend/models"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -131,6 +132,10 @@ func (jc *JobController) GetJobs(c *gin.Context) {
 	}
 	if visibility := c.Query("visibility"); visibility != "" {
 		query = query.Where("visibility = ?", visibility)
+	}
+	if keyword := c.Query("keyword"); keyword != "" {
+		keywordPattern := fmt.Sprintf("%%%s%%", keyword)
+		query = query.Where("title LIKE ? OR description LIKE ?", keywordPattern, keywordPattern)
 	}
 
 	limit, err := strconv.Atoi(c.DefaultQuery("limit", "30"))

--- a/backend/controllers/router.go
+++ b/backend/controllers/router.go
@@ -25,7 +25,6 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 
 	job := requiredLogin.Group("/job")
 	job.GET("/", jobController.GetJobs)
-	job.GET("/:id", jobController.GetJobs)
 	job.POST("/", jobController.CreateJob)
 	job.PATCH("/:id", jobController.UpdateJob)
 	job.DELETE("/:id", jobController.DeleteJob)


### PR DESCRIPTION
## What's New
The API path /job now supports query parameters and can be used to filter jobs with specific criteria.
The query parameters include:
- id
- location
- job_type
- employment_status
- min_salary
- max_salary
- min_experience
- max_experience
- visibility
- keyword

---

## Acceptance Criteria
- [x] Return jobs that met the criteria givens (filtering by properties)
- [x] Return message indicating no jobs found when no jobs match the criteria
- [x] Keyword search return all jobs that include the keyword in the title of description

---

## Type of Change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor
- [ ] ✅ Test update
- [ ] ⚡ Performance improvement

---

## Reviewer Notes
- The API path /job/:id is removed since id is one of the query parameters
- There is currently no check on the query parameters (except id) because no job will be found if they're invalid but let me know if you want me to implement validation
- For the visibility query parameter, you have to use 0,1 as the value