### PR TITLE
Add role to response for /login

### DIFF
--- a/backend/controllers/authController.go
+++ b/backend/controllers/authController.go
@@ -154,6 +154,8 @@ func (ac *AuthController) Login(c *gin.Context) {
 		return
 	}
 
+	role := GetUserRole(ac.DB, userFound.ID)
+
 	generateToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"id":  userFound.ID,
 		"exp": time.Now().Add((time.Minute * 30)).Unix(),
@@ -179,7 +181,23 @@ func (ac *AuthController) Login(c *gin.Context) {
 	)
 
 	c.JSON(http.StatusOK, gin.H{
-		"message": "login successful",
-		"email":   userFound.Email,
+		"email": userFound.Email,
+		"role":  role,
 	})
+}
+
+func GetUserRole(DB *gorm.DB, userID uint) string {
+	var result struct{ UserID uint }
+
+	if err := DB.Table("students").Where("user_id = ?", userID).First(&result).Error; err == nil {
+		return "student"
+	}
+	if err := DB.Table("companies").Where("user_id = ?", userID).First(&result).Error; err == nil {
+		return "company"
+	}
+	if err := DB.Table("admins").Where("user_id = ?", userID).First(&result).Error; err == nil {
+		return "admin"
+	}
+
+	return ""
 }


### PR DESCRIPTION
## What's New
Add a field called `role` to response of `/auth/login`
The role can be either `student`, `company`, `admin`, or empty

---

## Acceptance Criteria
- [x] The role field is included in the response and correctly match the role of user in database

---

## Type of Change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor
- [ ] ✅ Test update
- [ ] ⚡ Performance improvement

---

## Reviewer Notes
This exists for frontend to identify the role of user, so please store the value in local storage.
You can store the email which is also a part of the response as well.