### PR TITLE
Add API for deleting job applications for company accounts

### DIFF
--- a/backend/controllers/jobApplicationController.go
+++ b/backend/controllers/jobApplicationController.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"com-seek/backend/models"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -78,4 +79,41 @@ func (jc *JobApplicationController) CreateJobApplication(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "successfully applied"})
+}
+
+func (jc *JobApplicationController) DeleteJobApplication(c *gin.Context) {
+	userID := c.MustGet("userID").(uint)
+	jobApplicationIDStr := c.Param("id")
+
+	var jobApplicationID uint
+
+	u, err := strconv.ParseUint(jobApplicationIDStr, 10, strconv.IntSize)
+
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid ID"})
+		return
+	}
+
+	jobApplicationID = uint(u)
+
+	jobApplication := models.JobApplication{
+		ID: jobApplicationID,
+	}
+
+	if err := jc.DB.Preload("Job").First(&jobApplication).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "job application not found"})
+		return
+	}
+
+	if jobApplication.Job.CompanyID != userID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	if err := jc.DB.Delete(&jobApplication).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "successfully deleted the job application"})
 }

--- a/backend/controllers/router.go
+++ b/backend/controllers/router.go
@@ -45,6 +45,7 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	job.PATCH("/:id", jobController.UpdateJob)
 	job.DELETE("/:id", jobController.DeleteJob)
 	job.POST("/apply", JobApplicationController.CreateJobApplication)
+	job.DELETE("/application/:id", JobApplicationController.DeleteJobApplication)
 
 	admin := requiredLogin.Group("/admin")
 	admin.PATCH("review-company/:id", adminController.ReviewCompany)


### PR DESCRIPTION
## What's New
- API path /job/application/:id (job application id) to delete any job application submitted to a job posting owned by the user's account

---

## Acceptance Criteria
- [x] The job application is deleted correctly
- [x] No job application is deleted if the job is not owned by the user

---

## Type of Change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor
- [ ] ✅ Test update
- [ ] ⚡ Performance improvement

---