### PR TITLE
Fix only able to apply job once

### DIFF
--- a/backend/controllers/jobApplicationController.go
+++ b/backend/controllers/jobApplicationController.go
@@ -66,7 +66,7 @@ func (jc *JobApplicationController) CreateJobApplication(c *gin.Context) {
 		JobID:     job.ID,
 	}
 
-	result := jc.DB.FirstOrCreate(&jobApplication)
+	result := jc.DB.Where("student_id = ? AND job_id = ?", student.UserID, job.ID).FirstOrCreate(&jobApplication)
 
 	if result.Error != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": result.Error.Error()})


### PR DESCRIPTION
## What's New
Fix creating job application always return `job application already exists` when the user owns any job application

---

## Acceptance Criteria
- [x] Job application should be created if different job id is given

---

## Type of Change
- [ ] 🚀 New feature
- [x] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor
- [ ] ✅ Test update
- [ ] ⚡ Performance improvement

---