### PR TITLE
Safer GET `/job` and add visibility field to PATCH `/job/:id`

### DIFF
--- a/backend/controllers/jobController.go
+++ b/backend/controllers/jobController.go
@@ -144,11 +144,6 @@ func (jc *JobController) GetJobs(c *gin.Context) {
 		return
 	}
 
-	if len(jobs) == 0 {
-		c.JSON(http.StatusOK, gin.H{"jobs": jobs})
-		return
-	}
-
 	c.JSON(http.StatusOK, gin.H{"jobs": jobs})
 }
 


### PR DESCRIPTION
## What's New
- Remove visibility query parameter from API path GET `/job`
- API path GET `/job` now only return visible approved jobs (to ensure that no one can see invisible or unapproved job using this API)
- API path PATCH `job/:id` now can update jobs' visibility

---

## Acceptance Criteria
- [x] Only visible approved jobs are returned and remaining query parameters function the same
- [x] Job visibility is updated correctly

---

## Type of Change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor
- [ ] ✅ Test update
- [ ] ⚡ Performance improvement

---

## Reviewer Notes
- The visibility field in the body should be either `true` or `false` for requests to PATCH `job/:id` if given