### PR TITLE
Implement rate limit for APIs

### DIFF
--- a/backend/controllers/router.go
+++ b/backend/controllers/router.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"com-seek/backend/config"
 	"com-seek/backend/middlewares"
+	"net/http"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -24,42 +25,42 @@ func NewRouter(db *gorm.DB, fileConfig config.FileConfig) *gin.Engine {
 	adminController := NewAdminController(db)
 
 	authGroup := router.Group("/auth")
-	authGroup.POST("/register/student", authController.RegisterStudent)
-	authGroup.POST("/register/company", authController.RegisterCompany)
-	authGroup.POST("/login", authController.Login)
+	authGroup.POST("/register/student", middlewares.RateLimiterFor(http.MethodPost), authController.RegisterStudent)
+	authGroup.POST("/register/company", middlewares.RateLimiterFor(http.MethodPost), authController.RegisterCompany)
+	authGroup.POST("/login", middlewares.RateLimiterFor(http.MethodPost), authController.Login)
 	authGroup.POST("/logout", middlewares.CheckAuth, authController.Logout)
 
 	requiredLogin := router.Group("/", middlewares.CheckAuth)
 
-	requiredLogin.GET("/file/:uuid", fileController.ServeFile)
+	requiredLogin.GET("/file/:uuid", middlewares.RateLimiterFor(http.MethodGet), fileController.ServeFile)
 
 	student := requiredLogin.Group("/student")
-	student.GET("", studentController.GetStudentProfile)
-	student.GET("/:id", studentController.GetStudentProfile)
-	student.PATCH("", studentController.UpdateStudentProfile)
+	student.GET("", middlewares.RateLimiterFor(http.MethodGet), studentController.GetStudentProfile)
+	student.GET("/:id", middlewares.RateLimiterFor(http.MethodGet), studentController.GetStudentProfile)
+	student.PATCH("", middlewares.RateLimiterFor(http.MethodPatch), studentController.UpdateStudentProfile)
 
 	company := requiredLogin.Group("/company")
-	company.GET("", companyController.GetCompanyProfile)
-	company.GET("/:id", companyController.GetCompanyProfile)
-	company.PATCH("", companyController.UpdateCompanyProfile)
-	company.GET("/jobs", companyController.GetCompanyJobs)
+	company.GET("", middlewares.RateLimiterFor(http.MethodGet), companyController.GetCompanyProfile)
+	company.GET("/:id", middlewares.RateLimiterFor(http.MethodGet), companyController.GetCompanyProfile)
+	company.PATCH("", middlewares.RateLimiterFor(http.MethodPatch), companyController.UpdateCompanyProfile)
+	company.GET("/jobs", middlewares.RateLimiterFor(http.MethodGet), companyController.GetCompanyJobs)
 
 	job := requiredLogin.Group("/job")
-	job.GET("", jobController.GetJobs)
-	job.POST("", jobController.CreateJob)
-	job.GET("/:id", jobController.GetJob)
-	job.PATCH("/:id", jobController.UpdateJob)
-	job.DELETE("/:id", jobController.DeleteJob)
-	job.POST("/apply", JobApplicationController.CreateJobApplication)
-	job.DELETE("/application/:id", JobApplicationController.DeleteJobApplication)
+	job.GET("", middlewares.RateLimiterFor(http.MethodGet), jobController.GetJobs)
+	job.POST("", middlewares.RateLimiterFor(http.MethodPost), jobController.CreateJob)
+	job.GET("/:id", middlewares.RateLimiterFor(http.MethodGet), jobController.GetJob)
+	job.PATCH("/:id", middlewares.RateLimiterFor(http.MethodPatch), jobController.UpdateJob)
+	job.DELETE("/:id", middlewares.RateLimiterFor(http.MethodDelete), jobController.DeleteJob)
+	job.POST("/apply", middlewares.RateLimiterFor(http.MethodPost), JobApplicationController.CreateJobApplication)
+	job.DELETE("/application/:id", middlewares.RateLimiterFor(http.MethodDelete), JobApplicationController.DeleteJobApplication)
 
 	admin := requiredLogin.Group("/admin")
-	admin.PATCH("review-company/:id", adminController.ReviewCompany)
-	admin.PATCH("review-student/:id", adminController.ReviewStudent)
-	admin.PATCH("review-job/:id", adminController.ReviewJob)
-	admin.GET("/companies", adminController.GetPendingCompanies)
-	admin.GET("/students", adminController.GetPendingStudents)
-	admin.GET("/jobs", adminController.GetPendingJobs)
+	admin.PATCH("review-company/:id", middlewares.RateLimiterFor(http.MethodPatch), adminController.ReviewCompany)
+	admin.PATCH("review-student/:id", middlewares.RateLimiterFor(http.MethodPatch), adminController.ReviewStudent)
+	admin.PATCH("review-job/:id", middlewares.RateLimiterFor(http.MethodPatch), adminController.ReviewJob)
+	admin.GET("/companies", middlewares.RateLimiterFor(http.MethodGet), adminController.GetPendingCompanies)
+	admin.GET("/students", middlewares.RateLimiterFor(http.MethodGet), adminController.GetPendingStudents)
+	admin.GET("/jobs", middlewares.RateLimiterFor(http.MethodGet), adminController.GetPendingJobs)
 
 	return router
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,10 +4,13 @@ go 1.24.2
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/JGLTechnologies/gin-rate-limit v1.5.6 // indirect
 	github.com/bytedance/sonic v1.13.3 // indirect
 	github.com/bytedance/sonic/loader v0.2.4 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.11 // indirect
 	github.com/gin-contrib/cors v1.7.6 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
@@ -29,6 +32,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	golang.org/x/arch v0.18.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/JGLTechnologies/gin-rate-limit v1.5.6 h1:BrL2wXrF7SSqmB88YTGFVKMGVcjURMUeKqwQrlmzweI=
+github.com/JGLTechnologies/gin-rate-limit v1.5.6/go.mod h1:fwUuBegxLKm8+/4ST0zDFssRFTFaVZ7bH3ApK7iNZww=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic v1.13.3 h1:MS8gmaH16Gtirygw7jV91pDCN33NyMrPbN7qiYhEsF0=
@@ -8,6 +10,8 @@ github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3z
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCNan80NzY=
 github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
@@ -16,6 +20,8 @@ github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
@@ -92,6 +98,8 @@ github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
+github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/backend/middlewares/rateLimit.go
+++ b/backend/middlewares/rateLimit.go
@@ -1,0 +1,57 @@
+package middlewares
+
+import (
+	"net/http"
+	"time"
+
+	ratelimit "github.com/JGLTechnologies/gin-rate-limit"
+	"github.com/gin-gonic/gin"
+)
+
+var methodLimits = map[string]uint{
+	http.MethodGet:    100,
+	http.MethodPost:   5,
+	http.MethodPatch:  15,
+	http.MethodDelete: 15,
+}
+
+var rateLimiters map[string]gin.HandlerFunc
+
+func init() {
+	rateLimiters = make(map[string]gin.HandlerFunc, len(methodLimits))
+	for method, limit := range methodLimits {
+		rateLimiters[method] = newRateLimiter(limit)
+	}
+}
+
+func RateLimiterFor(method string) gin.HandlerFunc {
+	if mw, ok := rateLimiters[method]; ok {
+		return mw
+	}
+
+	return func(c *gin.Context) { c.Next() }
+}
+
+func keyFunc(c *gin.Context) string {
+	return c.ClientIP()
+}
+
+func rateLimitErrorHandler(c *gin.Context, info ratelimit.Info) {
+	c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+		"error": "too many requests, please try again in " + time.Until(info.ResetTime).String(),
+	})
+}
+
+func newRateLimiter(limit uint) gin.HandlerFunc {
+	store := ratelimit.InMemoryStore(&ratelimit.InMemoryOptions{
+		Rate:  time.Minute,
+		Limit: limit,
+	})
+
+	mw := ratelimit.RateLimiter(store, &ratelimit.Options{
+		ErrorHandler: rateLimitErrorHandler,
+		KeyFunc:      keyFunc,
+	})
+
+	return mw
+}


### PR DESCRIPTION
## What's New
- Rate limit for backend APIs with the specification of
  - GET : 100 requests / minute
  - POST: 5 requests / minute
  - PATCH: 15 requests / minute
  - DELETE: 15 requests / minute

---

## Acceptance Criteria
- [ ] The server block requests from IP that sent too many requests

---

## Type of Change
- [x] 🚀 New feature
- [ ] 🐛 Bug fix
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor
- [ ] ✅ Test update
- [ ] ⚡ Performance improvement

---

## Reviewer Notes
- You can spam invalid requests to test this quickly.